### PR TITLE
Vertex and fragment shaders can be compiled and used

### DIFF
--- a/LlamaEngine/LlamaEngine.vcxproj
+++ b/LlamaEngine/LlamaEngine.vcxproj
@@ -125,7 +125,14 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
-    <ClCompile Include="Main.cpp" />
+    <ClCompile Include="src\Main.cpp" />
+    <ClCompile Include="src\graphics\Shader.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="src\graphics\Shader.hpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="res\shader\Basic.glsl" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/LlamaEngine/LlamaEngine.vcxproj.filters
+++ b/LlamaEngine/LlamaEngine.vcxproj.filters
@@ -6,8 +6,15 @@
     </Filter>
   </ItemGroup>
   <ItemGroup>
-    <ClCompile Include="Main.cpp">
+    <ClCompile Include="src\Main.cpp">
       <Filter>src</Filter>
     </ClCompile>
+    <ClCompile Include="src\graphics\Shader.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="res\shader\Basic.glsl" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="src\graphics\Shader.hpp" />
   </ItemGroup>
 </Project>

--- a/LlamaEngine/res/shader/Basic.glsl
+++ b/LlamaEngine/res/shader/Basic.glsl
@@ -1,0 +1,15 @@
+#vertex
+#version 330 core
+
+layout(location = 0) in vec2 position;
+void main() {
+	gl_Position = vec4(position, 0, 1);
+}
+
+#fragment
+#version 330 core
+
+out vec4 colour;
+void main() {
+	colour = vec4(0, 0, 0, 1);
+}

--- a/LlamaEngine/src/Main.cpp
+++ b/LlamaEngine/src/Main.cpp
@@ -1,7 +1,11 @@
 #include <iostream>
 #include <gl/glew.h>
 #include <GLFW/glfw3.h>
+#include "graphics/Shader.hpp"
 int main() {
+	using namespace engine;
+	using namespace graphics;
+
 	if (!glfwInit()) {
 		std::cout << "Failed to initialise GLFW" << std::endl;
 		return -1;
@@ -17,6 +21,9 @@ int main() {
 		std::cout << "Failed to initialise GLEW" << std::endl;
 		return -1;
 	}
+
+	Shader* shader = new Shader("res/shader/Basic.glsl");
+	shader->bind();
 
 	while (!glfwWindowShouldClose(window)) {
 		glClearColor(1, 1, 1, 1);

--- a/LlamaEngine/src/graphics/Shader.cpp
+++ b/LlamaEngine/src/graphics/Shader.cpp
@@ -1,0 +1,90 @@
+#include "Shader.hpp"
+#include <gl/glew.h>
+#include <string>
+#include <sstream>
+#include <fstream>
+#include <iostream>
+
+namespace engine {
+	namespace graphics {
+
+		Shader::Shader(const char* file) : Shader(Shader::parse(Shader::read(file))) { }
+		Shader::Shader(ShaderSource sources) {
+			this->program = glCreateProgram();
+			unsigned int vertex = glCreateShader(GL_VERTEX_SHADER);
+			unsigned int fragment = glCreateShader(GL_FRAGMENT_SHADER);
+
+			Shader::compile(vertex, sources.vertex.c_str());
+			Shader::compile(fragment, sources.fragment.c_str());
+
+			glAttachShader(this->program, vertex);
+			glAttachShader(this->program, fragment);
+			glLinkProgram(this->program);
+
+			int linked;
+			glGetProgramiv(this->program, GL_LINK_STATUS, &linked);
+			if (!linked) {
+				int length = 0;
+				char message[1024];
+				glGetProgramInfoLog(this->program, 1024, &length, message);
+				std::cout << "[PROGRAM] " << message << std::endl;
+			}
+
+			glDeleteShader(vertex);
+			glDeleteShader(fragment);
+		}
+
+		std::string Shader::read(const char* file) {
+			std::fstream stream(file);
+			std::string line;
+			std::stringstream contents;
+			while (std::getline(stream, line))
+				contents << line << std::endl;
+
+			return contents.str();
+		}
+
+		ShaderSource Shader::parse(std::string contents) {
+			std::istringstream stuff(contents);
+			std::stringstream shaders[2];
+			std::string line;
+			int mode = -1;
+			while (std::getline(stuff, line)) {
+				if (line.compare(0, 7, "#vertex") == 0)
+					mode = 0;
+				else if (line.compare(0, 9, "#fragment") == 0)
+					mode = 1;
+				else if (mode != -1)
+					shaders[mode] << line << std::endl;
+			}
+
+			return {
+				shaders[0].str(),
+				shaders[1].str()
+			};
+		}
+
+		void Shader::compile(unsigned int shader, const char* src) {
+			glShaderSource(shader, 1, &src, 0);
+			glCompileShader(shader);
+			int compiled;
+			glGetShaderiv(shader, GL_COMPILE_STATUS, &compiled);
+			if (!compiled) {
+				int length = 0;
+				char message[1024];
+				glGetShaderInfoLog(shader, 1024, &length, message);
+				std::cout << "[SHADER] " << message << std::endl;
+			}
+		}
+
+
+		void Shader::bind() {
+			glUseProgram(this->program);
+		}
+
+		void Shader::unbind() {
+			glUseProgram(0);
+		}
+
+	}
+}

--- a/LlamaEngine/src/graphics/Shader.hpp
+++ b/LlamaEngine/src/graphics/Shader.hpp
@@ -1,0 +1,25 @@
+#pragma once
+#include <string>
+
+namespace engine {
+	namespace graphics {
+		
+		struct ShaderSource {
+			std::string vertex;
+			std::string fragment;
+		};
+		class Shader {
+		public:
+			unsigned int program;
+			Shader(const char* file);
+			Shader(ShaderSource sources);
+			static std::string read(const char* file);
+			static ShaderSource parse(std::string contents);
+			static void compile(unsigned int shader, const char* src);
+
+			void bind();
+			void unbind();
+		};
+
+	}
+}


### PR DESCRIPTION
Now you can create a new instance of the Shader class, and compile vertex shaders and fragment shaders. You can also bind them to use them for rendering stuff!